### PR TITLE
Example for encrypted databags

### DIFF
--- a/cookbooks/mytestcookbook/recipes/encrypted_databag_demo.rb
+++ b/cookbooks/mytestcookbook/recipes/encrypted_databag_demo.rb
@@ -1,0 +1,10 @@
+# simple search
+
+data_bag_item = Chef::EncryptedDataBagItem.load("my_data_bag", "my_item")
+
+file "/etc/my_file" do
+  content data_bag_item["fun data"]
+  mode 00644
+  not_if {data_bag_item.empty?}
+  action :create # must have action, chefspec will not default action :create
+end

--- a/cookbooks/mytestcookbook/spec/stub_out_encrypted_databag_spec.rb
+++ b/cookbooks/mytestcookbook/spec/stub_out_encrypted_databag_spec.rb
@@ -1,0 +1,11 @@
+require 'bundler/setup'
+require 'chefspec'
+
+describe 'stub out encrypted databags' do
+  let (:chef_run) { ChefSpec::ChefRunner.new.converge 'mytestcookbook::encrypted_databag_demo' }
+  it 'stub out data_bag_item' do
+    Chef::Recipe.any_instance.stub(:data_bag_item).and_return(Hash.new)
+    Chef::EncryptedDataBagItem.stub(:load).with("my_data_bag", "my_item").and_return({"id" => "my_item", "fun data" => "whatever"})
+    expect(chef_run).to create_file_with_content('/etc/my_file', 'whatever')
+  end
+end


### PR DESCRIPTION
This is a simple example based on https://github.com/jimhopp/chefspec_exploration/blob/master/cookbooks/mytestcookbook/spec/stub_out_databag_spec.rb

It demonstrates how to stub out EncryptedDatabagItems. 
